### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/PedanticArgs/ad68935d-410d-4fa9-a184-2a388c3b8749/84d25372-6d3b-4889-a8d3-419f1a7dcc33/_apis/work/boardbadge/451939de-38b2-4e01-b741-40665e78adbc)](https://dev.azure.com/PedanticArgs/ad68935d-410d-4fa9-a184-2a388c3b8749/_boards/board/t/84d25372-6d3b-4889-a8d3-419f1a7dcc33/Microsoft.RequirementCategory)
 Pedantic Arguments
 
 ![5359485302c3505c4a56011f13a0a506](https://user-images.githubusercontent.com/19936494/232830718-d61eb744-e358-4d75-9524-0c9b8c990cdf.jpg)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#15](https://dev.azure.com/PedanticArgs/ad68935d-410d-4fa9-a184-2a388c3b8749/_workitems/edit/15). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.